### PR TITLE
Fix: avoid early return in latenzy peak refinement

### DIFF
--- a/latenzy/matlab/latenzy.m
+++ b/latenzy/matlab/latenzy.m
@@ -167,7 +167,11 @@ while doContinue
     %get temporal deviation
     [realDiff,realTime,spikeFrac,fracLinear] = calcTempDiff(pseudoSpikeTimes,pseudoEventTimes,thisMaxDur);
     if numel(realDiff) < 3
-        return
+        if any(keepPeaks)
+            break
+        else
+            return
+        end
     end
     
     %get largest deviation

--- a/latenzy/matlab/latenzy2.m
+++ b/latenzy/matlab/latenzy2.m
@@ -207,7 +207,11 @@ while doContinue
     [realDiff,realTime,spikeFrac1,~,spikeFrac2,~,tempDiffUnSub,fracLinear] = ...
         calcTempDiff2(spikesPerEvent1,spikesPerEvent2,thisMaxDur,useFastInterp);
     if numel(realDiff) < 3
-        return
+        if any(keepPeaks)
+            break
+        else
+            return
+        end
     end
 
     %get largest deviation

--- a/latenzy/python/latenzy.py
+++ b/latenzy/python/latenzy.py
@@ -132,6 +132,8 @@ def latenzy(spike_times,
 
         real_diff, real_time, spike_frac, frac_linear = calc_temp_diff(pseudo_spike_times, pseudo_event_times, this_max_dur)
         if len(real_diff) < 3:
+            if any(keep_peaks):
+                break
             return np.nan, {}
 
         # Peak detection
@@ -347,6 +349,8 @@ def latenzy2(
             calc_temp_diff2(spikes1, spikes2, this_max_dur)
 
         if len(real_diff) < 3:
+            if any(keep_peaks):
+                break
             return np.nan, {}
 
         # Peak detection


### PR DESCRIPTION
Fixes #14 

This PR fixes the refinement logic in both the MATLAB and Python implementations of `latenzy`.

When a later refinement iteration produces fewer than three temporal-deviation points, the previous code returns immediately and can discard peaks that were already accepted in earlier iterations.

Keep the original early-return behavior when no peak has been accepted yet, but stop refinement once a valid peak already exists so the last accepted latency is preserved.